### PR TITLE
Issue 136 Windows 11 terminal

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
       # pub400 closes the connection if there are too many requests coming from the same IP address
       max-parallel: 1
       matrix:
-        python-version: ["3.8", "3.12"]
+        python-version: ["3.8", "3.12", "3.13"]
         os: [ubuntu-latest, windows-latest]
       fail-fast: false
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,69 +19,69 @@ jobs:
       fail-fast: false
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-    - name: Set up python
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Set up python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies linux
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        sudo apt-get install -y xvfb x3270 locales xterm
-        sudo locale-gen en_US
+      - name: Install dependencies linux
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get install -y xvfb x3270 locales xterm
+          sudo locale-gen en_US
 
-    - name: Install dependencies windows
-      if: matrix.os == 'windows-latest'
-      run: |
-        choco install wc3270
-        echo "C:\Program Files\wc3270" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Install dependencies windows
+        if: matrix.os == 'windows-latest'
+        run: |
+          choco install wc3270
+          echo "C:\Program Files\wc3270" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
-    - name: Install python dependencies
-      run: |
-        python -m pip install -r requirements-dev.txt
+      - name: Install python dependencies
+        run: |
+          python -m pip install -r requirements-dev.txt
 
-    - name: Lint
-      run: |
-        inv lint
+      - name: Lint
+        run: |
+          inv lint
 
-    - name: Run utests with coverage
-      run: |
-        coverage run --branch --source Mainframe3270/ -m pytest --verbose utest/
-        coverage report
-        coverage xml
+      - name: Run utests with coverage
+        run: |
+          coverage run --branch --source Mainframe3270/ -m pytest --verbose utest/
+          coverage report
+          coverage xml
 
-    - name: Upload unit test coverage to Codecov
-      uses: codecov/codecov-action@v3
-      with:
-        files: coverage.xml
-        flags: unit
-        move_coverage_to_trash: true
+      - name: Upload unit test coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: coverage.xml
+          flags: unit
+          move_coverage_to_trash: true
 
-    - name: Run atests with coverage linux
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        LANG=en_US.iso88591 xvfb-run coverage run --branch --source Mainframe3270/ -m robot $ROBOT_OPTIONS atest/
-        coverage report
-        coverage xml
+      - name: Run atests with coverage linux
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          LANG=en_US.iso88591 xvfb-run coverage run --branch --source Mainframe3270/ -m robot $ROBOT_OPTIONS atest/
+          coverage report
+          coverage xml
 
-    - name: Run atests with coverage windows
-      if: matrix.os == 'windows-latest'
-      run: |
-        coverage run --branch --source Mainframe3270/ -m robot $ROBOT_OPTIONS atest/
-        coverage report
-        coverage xml
+      - name: Run atests with coverage windows
+        if: matrix.os == 'windows-latest'
+        run: |
+          coverage run --branch --source Mainframe3270/ -m robot $ROBOT_OPTIONS atest/
+          coverage report
+          coverage xml
 
-    - name: Upload acceptance tests coverage to Codecov
-      uses: codecov/codecov-action@v3
-      with:
-        files: coverage.xml
-        flags: acceptance
+      - name: Upload acceptance tests coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: coverage.xml
+          flags: acceptance
 
-    - uses: actions/upload-artifact@v3
-      if: ${{ always() }}
-      with:
-        name: Tests results python${{ matrix.python-version }} - ${{ matrix.os }}
-        path: logs/
+      - uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: Tests results python${{ matrix.python-version }} - ${{ matrix.os }}
+          path: logs/

--- a/Mainframe3270/py3270.py
+++ b/Mainframe3270/py3270.py
@@ -506,6 +506,30 @@ class Emulator(object):
         full_text = ""
         for ypos in range(self.model_dimensions["rows"]):
             full_text += self.string_get(ypos + 1, 1, self.model_dimensions["columns"])
+
+        # The following section is necessary for cross platform compatibility if the host application contains some special characters.
+        # It replaces the unicode values with the corresponding characters to prevent positioning errors which are caused by the different client implementations (wc3270 vs. x3270)
+
+        # Replace various box drawing character patterns (multiple stages for different character types, I added them one by one to catch all cases in out tests)
+
+        # Stage 1: Replace specific multi-byte sequences
+        full_text = full_text.replace("â\x94\x80", "-")  # Horizontal line
+        full_text = full_text.replace("â\x94\x82", "|")  # Vertical line
+        full_text = full_text.replace("â\x94\x8c", "+")  # Top-left corner
+        full_text = full_text.replace("â\x94\x90", "+")  # Top-right corner
+        full_text = full_text.replace("â\x94\x94", "+")  # Bottom-left corner
+        full_text = full_text.replace("â\x94\x98", "+")  # Bottom-right corner
+
+        # Stage 2: Replace any remaining 'â' characters (not sure if this could cause issues if you really want the 'â' character)
+        full_text = full_text.replace("â", "-")
+
+        # Only replace if full_text is a string (in the unit tests these are provided as an instance of MagicMock)
+        if isinstance(full_text, str):
+            # Stage 3: Replace Unicode box drawing range
+            full_text = re.sub(r"[\u2500-\u257F]", "-", full_text)
+
+            # Stage 4: Replace any non-ASCII characters that might be box drawing
+            full_text = re.sub(r"[^\x20-\x7E]", "-", full_text, flags=re.UNICODE)
         return full_text
 
     def delete_field(self):

--- a/Mainframe3270/py3270.py
+++ b/Mainframe3270/py3270.py
@@ -4,6 +4,7 @@ import math
 import re
 import socket
 import subprocess
+import sys
 import time
 import warnings
 from abc import ABC, abstractmethod
@@ -206,11 +207,16 @@ class wc3270App(ExecutableApp):
         self.socket.close()
 
     def spawn_app(self, host):
-        args = ["start", "/wait", self.executable] + self.args
+        # check if we need to run a different start command when running in Windows 11
+        is_win10 = sys.getwindowsversion().build < 22000
+        if is_win10:
+            args = ["start", "/wait", self.executable] + self.args
+        else:
+            args = ["cmd.exe", "/c", "start", "/wait", "conhost", self.executable] + self.args
         args.extend(["-scriptport", str(self.script_port), host])
         self.sp = subprocess.Popen(
             args,
-            shell=True,
+            shell=is_win10,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,

--- a/atest/mainframe.robot
+++ b/atest/mainframe.robot
@@ -270,15 +270,15 @@ Test Get Current Position
 
 Test Get String Positions
     ${positions}    Get String Positions    Welcome
-    Should Be Equal    ${{ [(1, 10)] }}    ${positions}
+    Should Be Equal    ${{ [(1, 10), (9, 15)] }}    ${positions}
 
 Test Get String Positions Case-Insensitive
     ${positions}    Get String Positions    Welcome    ignore_case=True
-    Should Be Equal    ${{ [(1, 10), (9, 5)] }}    ${positions}
+    Should Be Equal    ${{ [(1, 10), (9, 15)] }}    ${positions}
 
 Test Get String Positions As Dict
     ${positions}    Get String Positions    Welcome    As Dict
-    Should Be Equal    ${{ [{"ypos": 1, "xpos": 10}] }}
+    Should Be Equal    ${{ [{"ypos": 1, "xpos": 10}, {"ypos": 9, "xpos": 15}] }}
     ...    ${positions}
 
 Test Get String Positions Without Result
@@ -297,10 +297,10 @@ Test Get String Positions Only After As Dict
 
 Test Get String Positions Only After Case-Insensitive
     ${positions}    Get String Positions Only After    9    4    Welcome    ignore_case=True
-    Should Be Equal    ${{ [(9, 5)] }}    ${positions}
+    Should Be Equal    ${{ [(9, 15)] }}    ${positions}
 
 Test Get String Positions Only After Without Results
-    ${positions}    Get String Positions Only After    9    5    Welcome    ignore_case=True
+    ${positions}    Get String Positions Only After    9    15    Welcome    ignore_case=True
     Should Be Empty    ${positions}
 
 Test Get String Positions Only Before


### PR DESCRIPTION
This MR contains a workaround for running the mainframe client in Windows 11 (#136).

If Windows 11 is detected as the executing platform it will use `conhost` with `shell=False` instead of the regular Windows Terminal to be backwards compatible.

The MR also contains a patch for special characters that are causing different position values depending if the client is Windows (wc3270) or Linux (x3270).

The provided tests and pipeline configuration was outdated, so I updated those as well. A successful Pipeline can be viewed here: https://github.com/fhennig42/Robot-Framework-Mainframe-3270-Library/actions/runs/16987717165/job/48160144012